### PR TITLE
k8s-26 : Fail to create infinidat-provisioner pod on Openshift

### DIFF
--- a/input.yaml
+++ b/input.yaml
@@ -118,11 +118,4 @@ spec:
                   name: mgmt-api-credentials
                   key: management_url
           imagePullPolicy: "Always"
-          volumeMounts:
-            - name: export-volume
-              mountPath: /export$imagepullsecret
-      volumes:
-        - name: export-volume
-          hostPath:
-            path: /tmp/infinidat-provisioner
 ---


### PR DESCRIPTION
added support for Openshift. now provisioner can be deployed on Openshift